### PR TITLE
mkvbox: implicitly write to stdout

### DIFF
--- a/bootstrap/mkvbox
+++ b/bootstrap/mkvbox
@@ -49,7 +49,7 @@ echo >&2
 echo add this to your ssh config: >&2
 echo >&2
 
-cat > /dev/stdout << EOF
+cat << EOF
 Host ${name}
 	User root
 	HostName localhost


### PR DESCRIPTION
Writing directly to `/dev/stdout` doesn't work when `sudo`ing to a user that is not in the `tty` group:

```
alice$ sudo -u bob -i
bob$ echo foo > /dev/stdout
bash: /dev/stdout: Permission denied
bob$ ls -Ll /dev/stdout
crw--w---- 1 alice tty  136, 12 Dec 11 16:52 /dev/stdout
```
