### PR TITLE
disambiguate `safe` to build in GHC 7.10

### DIFF
--- a/src/Upcast/Shell/Types.hs
+++ b/src/Upcast/Shell/Types.hs
@@ -117,7 +117,10 @@ escape xs = if all safe xs then xs else escaped
     f '`'  = "\\`"
     f x    = [x]
 
-    safe = (`elem` "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_=")
+    safe = (`elem` safeChars)
+
+    safeChars :: String
+    safeChars = "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_="
 
 maybeKey :: String -> Maybe String -> [String]
 maybeKey k = maybe mempty (\v -> [k, v])


### PR DESCRIPTION
otherwise you get this

```
src/Upcast/Shell/Types.hs:120:13:                                                                                                  
    No instance for (Foldable t0) arising from a use of ‘elem’                                                                     
    The type variable ‘t0’ is ambiguous                                                                                            
    Note: there are several potential instances:                                                                                   
      instance Foldable (Const m) -- Defined in ‘Control.Applicative’                                                              
      instance Foldable (Either a) -- Defined in ‘Data.Foldable’                                                                   
      instance Foldable Data.Functor.Identity.Identity                                                                             
        -- Defined in ‘Data.Functor.Identity’                                                                                      
      ...plus 28 others                                                                                                            
    In the expression:                                                                                                             
      (`elem`                                                                                                                      
       "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_=")                                                      
    In an equation for ‘safe’:                                                                                                     
        safe                                                                                                                       
          = (`elem`                                                                                                                
             "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_=")                                                
    In an equation for ‘escape’:                                                                                                   
        escape xs
          = if all safe xs then xs else escaped
          where
              escaped = "\"" ++ concatMap f xs ++ "\""
              f '\NUL' = ""
              f '"' = "\\\""
              f '\\' = "\\\\"
              f '!' = "\\!"
              f '$' = "\\$"
              f '`' = "\\`"
              f x = [x]
              safe
                = (`elem`
                   "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_=")

src/Upcast/Shell/Types.hs:120:20:
    No instance for (IsString (t0 Char))
      arising from the literal ‘"-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_="’
    The type variable ‘t0’ is ambiguous
    Note: there are several potential instances:
      instance IsString (dlist-0.7.1.1:Data.DList.DList Char)
        -- Defined in ‘dlist-0.7.1.1:Data.DList’
      instance IsString [Char] -- Defined in ‘Data.String’
    In the second argument of ‘elem’, namely
      ‘"-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_="’
    In the expression:
      (`elem`
       "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_=")
    In an equation for ‘safe’:
        safe
          = (`elem`
             "-./0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_=")
```