### PR TITLE
infra: avoid waiting for all instances to be running when empty 'infraEc2instance'

### DIFF
--- a/src/Upcast/Infra/Amazonka.hs
+++ b/src/Upcast/Infra/Amazonka.hs
@@ -412,8 +412,9 @@ plan expressionName userData keypairs Infras{..} =
                                          k
                                          v)
 
-    void $ await EC2.instanceRunning (EC2.describeInstances
-                                      & EC2.diiInstanceIds .~ map snd instanceA)
+    unless (null instanceA) $
+      await EC2.instanceRunning (EC2.describeInstances
+                                 & EC2.diiInstanceIds .~ map snd instanceA)
 
     forAttrs infraEc2instance $ \aname Ec2instance{..} ->
       forAttrs ec2instance_blockDeviceMapping $ \vname bdev ->


### PR DESCRIPTION
Previously: when 'infra' didn't describe any EC2 instances, provisioning
failed whenever any of our instances remained in a 'stopped' state for
the whole of 'DescribeInstances' waiter's polling period. This is
because when 'DescribeInstances' is passed an empty list of instance
IDs, it interprets this as a request for all of them.

Internally, we think of an empty 'ec2-instance' to mean we have no
expectations about EC2 instances, so just elide that 'await' in that
case.