### PR TITLE
Issue 60, break down IPPermissions with multiple IPRange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist
 /.cabal-sandbox*
 /shell.nix
+/.stack-work
 *.aterm
 *.hp
 *.prof


### PR DESCRIPTION
Break down IPPermissions with multiple IPRange into list of the same IPPermissions with single IPRange each, for correct diff in the 'converge' function.